### PR TITLE
Added "BuildRequires: update-desktop-files"

### DIFF
--- a/package/yast2-online-update.changes
+++ b/package/yast2-online-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 19 09:38:47 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "BuildRequires: update-desktop-files"
+- Related to the previous desktop file changes (fate#319035)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:35:20 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-online-update.spec
+++ b/package/yast2-online-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Url:            https://github.com/yast/yast-online-update
 Summary:        YaST2 - Online Update (YOU)
@@ -30,6 +30,7 @@ BuildRequires:	yast2-packager
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
+BuildRequires:  update-desktop-files
 
 # Product EOL tag
 Requires:       yast2-pkg-bindings >= 3.1.6


### PR DESCRIPTION
- The recent fix in YaST RPM macros now updates the desktop files
- The `%suse_update_desktop_file` macro is defined in the `update-desktop-files` package
- Without it the macro is not expanded and the shell treats `%` as a job control character and fails with error `fg: no job control`