### PR TITLE
Improved openSUSE/SLE detection (bsc#1184243)

### DIFF
--- a/package/yast2-online-update.changes
+++ b/package/yast2-online-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Apr  1 14:29:39 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Improved openSUSE/SLE detection (bsc#1184243)
+- Improved detecting the update repositories, check the "is_update_repo"
+  repository flag
+- 4.4.0
+
+-------------------------------------------------------------------
 Mon Aug 26 09:35:43 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-online-update.spec
+++ b/package/yast2-online-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update
-Version:        4.2.2
+Version:        4.4.0
 Release:        0
 Url:            https://github.com/yast/yast-online-update
 Summary:        YaST2 - Online Update (YOU)


### PR DESCRIPTION
- Improved openSUSE/SLE detection ([bsc#1184243](https://bugzilla.suse.com/show_bug.cgi?id=1184243))
  - The `Product.short_name` is read from `/etc/os-release`, in 15.3 it is "openSUSE Leap"
  - Unfortunately that does not match the expected "openSUSE" string
  - Make the check less strict, check for a substring and use `i` flag for case insensitive match
- Improved detecting the update repositories,  check the `is_update_repo` repository flag
  - It is `true` for the http://download.opensuse.org/update/leap/15.3/oss repository
  - If that fails check if any patch is available
- 4.4.0

Notes: `master` only, it works fine when at least one online update is available. Releasing this as an update would mean an update would be available so it would not be needed... So just wait until another update is released.