### PR TITLE
online_update: Check for -pkg UI Plug-In and Prompt to Install it if Needed

### DIFF
--- a/package/yast2-online-update.changes
+++ b/package/yast2-online-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 15 13:33:59 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Check for pkg UI extension (in interactive mode) and offer to
+  install it if not present (jsc#SLE-20346, jsc#SLE-20462)
+- 4.4.3
+
+-------------------------------------------------------------------
 Wed Sep 15 12:11:40 UTC 2021 - Stefan Schubert <schubi@suse.de>
 
 - Added recommends to yast2-online-update-frontend in order to

--- a/package/yast2-online-update.spec
+++ b/package/yast2-online-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Url:            https://github.com/yast/yast-online-update
 Summary:        YaST2 - Online Update (YOU)
@@ -34,8 +34,8 @@ BuildRequires:  update-desktop-files
 
 # Product EOL tag
 Requires:       yast2-pkg-bindings >= 3.1.6
-# Kernel::InformAboutKernelChange
-Requires:       yast2 >= 2.23.8
+# UIExtensionChecker
+Requires:       yast2 >= 4.4.18
 # PackageCallbacks::FormatPatchName
 Requires:       yast2-packager >= 2.13.159
 # Added Logger (replacement for y2error, y2milestone, ...)

--- a/package/yast2-online-update.spec
+++ b/package/yast2-online-update.spec
@@ -35,7 +35,7 @@ BuildRequires:  update-desktop-files
 # Product EOL tag
 Requires:       yast2-pkg-bindings >= 3.1.6
 # UIExtensionChecker
-Requires:       yast2 >= 4.4.18
+Requires:       yast2 >= 4.4.19
 # PackageCallbacks::FormatPatchName
 Requires:       yast2-packager >= 2.13.159
 # Added Logger (replacement for y2error, y2milestone, ...)

--- a/src/clients/online_update.rb
+++ b/src/clients/online_update.rb
@@ -25,6 +25,7 @@
 #              Cornelius Schumacher <cschum@suse.de>
 
 require "y2packager/resolvable"
+require "ui/ui_extension_checker"
 
 module Yast
   class OnlineUpdateClient < Client
@@ -128,6 +129,9 @@ module Yast
 
     # Main sequence for Online Update
     def OnlineUpdateSequence
+      ui_extension_checker = UIExtensionChecker.new("pkg")
+      return :cancel unless ui_extension_checker.ok?
+
       Wizard.CreateDialog
       Wizard.SetDesktopTitleAndIcon("org.opensuse.yast.OnlineUpdate")
       # help text for online-update initialization


### PR DESCRIPTION
## Trello

https://trello.com/c/gT8nMq7O/2635-3-featureshouldhave-handle-more-gracefully-when-libyui-libraries-are-missing


## Jira

- https://jira.suse.com/browse/SLE-20346
- https://jira.suse.com/browse/SLE-20462


## Related PRs

- Main PR: https://github.com/yast/yast-yast2/pull/1194
- https://github.com/yast/yast-packager/pull/578
- https://github.com/yast/yast-add-on/pull/114

## Short Description

If the "pkg" UI extension plug-in is not available (usually because it's not installed), offer to install it.

Since this module also has some non-interactive modes (which are probably pretty obsolete), this is only done when the module is started in interactive mode; the other modes don't need that "pkg" UI extension, so they can safely run without it.

For more information, see https://github.com/yast/yast-packager/pull/578

## Screenshots

![need-pkg-installed-qt](https://user-images.githubusercontent.com/11538225/133434569-45974db6-a6fa-4e03-bd29-f11097164730.png)

![need-pkg-installed-ncurses](https://user-images.githubusercontent.com/11538225/133434575-430ca38f-84e9-43c0-9e3d-426cda0bbf62.png)

