### PR TITLE
Support managing system in a chroot (bsc#1199840)

### DIFF
--- a/package/yast2-online-update.changes
+++ b/package/yast2-online-update.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun  8 07:15:29 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Support managing system in a chroot (bsc#1199840)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-online-update.spec
+++ b/package/yast2-online-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Url:            https://github.com/yast/yast-online-update
 Summary:        YaST2 - Online Update (YOU)

--- a/src/clients/do_online_update_auto.rb
+++ b/src/clients/do_online_update_auto.rb
@@ -29,6 +29,7 @@ module Yast
   class DoOnlineUpdateAutoClient < Client
     def main
       Yast.import "Pkg"
+      Yast.import "Installation"
 
       Builtins.y2milestone("----------------------------------------")
       Builtins.y2milestone("do_online_update auto started")
@@ -55,7 +56,7 @@ module Yast
       if @func == "Write"
         @ret = :auto
 
-        Pkg.TargetInit("/", false)
+        Pkg.TargetInit(Installation.destdir, false)
         Pkg.SourceStartManager(true)
         Pkg.PkgSolve(true)
 

--- a/src/clients/inst_you.rb
+++ b/src/clients/inst_you.rb
@@ -44,6 +44,7 @@ module Yast
       Yast.import "ProductFeatures"
       Yast.import "Stage"
       Yast.import "Wizard"
+      Yast.import "Installation"
 
       @saved_path = Ops.add(Directory.vardir, "/selected_patches.ycp")
       @restarted_path = Ops.add(Directory.vardir, "/continue_you")
@@ -114,10 +115,10 @@ module Yast
       PackageCallbacksInit.InitPackageCallbacks
 
       if @after_restart || Hack("init-target-and-sources")
-        Pkg.TargetInit("/", false) # reinitialize target after release notes were read (#232247)
+        Pkg.TargetInit(Installation.destdir, false) # reinitialize target after release notes were read (#232247)
       else
         Pkg.TargetFinish
-        Pkg.TargetInitialize("/")
+        Pkg.TargetInitialize(Installation.destdir)
         Pkg.TargetLoad
       end
       # source data are cleared in registration client, and

--- a/src/clients/online_update.rb
+++ b/src/clients/online_update.rb
@@ -53,6 +53,7 @@ module Yast
       Yast.import "URL"
       Yast.import "Wizard"
       Yast.import "GetInstArgs"
+      Yast.import "Installation"
 
       # the command line description map
       @cmdline = {
@@ -178,7 +179,7 @@ module Yast
       Progress.NextStage
 
       # initialize target to import all trusted keys (#165849)
-      Pkg.TargetInit("/", false)
+      Pkg.TargetInit(Installation.destdir, false)
 
       Progress.NextStage
 


### PR DESCRIPTION
## Problem

- This is similar to https://github.com/yast/yast-add-on/pull/126
- The package manager is wrongly initialized when running in a container

## Solution

- Use `Installation.destdir` everywhere

## Testing

- Tested manually
