### PR TITLE
Bsc1204907

### DIFF
--- a/package/yast2-online-update.changes
+++ b/package/yast2-online-update.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Nov  1 08:14:59 UTC 2022 - Michal Filka <mfilka@suse.com>
+
+- bsc#1204907
+  - Dropped old workaround from 2.13.15 with unconditional refresh
+    of all repositories.
+- 4.4.4 
+
+-------------------------------------------------------------------
 Wed Sep 15 13:33:59 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Check for pkg UI extension (in interactive mode) and offer to

--- a/package/yast2-online-update.spec
+++ b/package/yast2-online-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update
-Version:        4.4.3
+Version:        4.4.4
 Release:        0
 Url:            https://github.com/yast/yast-online-update
 Summary:        YaST2 - Online Update (YOU)

--- a/src/clients/online_update.rb
+++ b/src/clients/online_update.rb
@@ -182,8 +182,6 @@ module Yast
 
       Progress.NextStage
 
-      OnlineUpdateCallbacks.RefreshAllSources
-
       Progress.NextStage
 
       if !OnlineUpdate.cd_update # CD for cd update was not initialized yet

--- a/src/clients/online_update.rb
+++ b/src/clients/online_update.rb
@@ -182,6 +182,16 @@ module Yast
 
       Progress.NextStage
 
+      enabled_only = true
+      mgr_ok = Pkg.SourceStartManager(enabled_only)
+      if !mgr_ok
+        Report.LongWarning(
+          # TRANSLATORS: error popup (detailed info follows)
+          _("There was an error in the repository initialization.") + "\n" +
+          Pkg.LastError
+        )
+      end
+
       Progress.NextStage
 
       if !OnlineUpdate.cd_update # CD for cd update was not initialized yet

--- a/src/modules/OnlineUpdateCallbacks.rb
+++ b/src/modules/OnlineUpdateCallbacks.rb
@@ -537,43 +537,6 @@ module Yast
       nil
     end
 
-    # Refresh all sources with autorefresh enabled.
-    # This function is a temporary solution for bug #154990
-    def RefreshAllSources
-      Builtins.y2milestone("Refreshing all sources...")
-      mgr_ok = Pkg.SourceStartManager(true)
-      if !mgr_ok
-        # error popoup (detailed info follows)
-        Report.LongWarning(
-          Ops.add(
-            _("There was an error in the repository initialization.") + "\n",
-            Pkg.LastError
-          )
-        )
-      end
-
-      all_sources = Pkg.SourceEditGet
-
-      # There are no sources, nothing to refresh
-      if all_sources == nil || Ops.less_than(Builtins.size(all_sources), 1)
-        Builtins.y2warning("No sources defined, nothing to refresh...")
-        return
-      end
-      Builtins.foreach(all_sources) do |one_source|
-        source_id = Ops.get_integer(one_source, "SrcId")
-        source_autorefresh = Ops.get_boolean(one_source, "autorefresh", true)
-        source_enabled = Ops.get_boolean(one_source, "enabled", true)
-        if source_id != nil && source_autorefresh == true &&
-            source_enabled == true
-          Builtins.y2milestone("Refreshing source: %1", source_id)
-          Pkg.SourceRefreshNow(source_id)
-        end
-      end
-      Builtins.y2milestone("... refreshing done")
-
-      nil
-    end
-
     # Refresh sources given by argument
     def RefreshSources(sources)
       sources = deep_copy(sources)
@@ -616,7 +579,6 @@ module Yast
     publish :function => :ScriptFinish, :type => "void ()"
     publish :function => :Message, :type => "boolean (string, string, string, string)"
     publish :function => :RegisterOnlineUpdateCallbacks, :type => "void ()"
-    publish :function => :RefreshAllSources, :type => "void ()"
     publish :function => :RefreshSources, :type => "void (list <map>)"
   end
 

--- a/src/modules/OnlineUpdateDialogs.rb
+++ b/src/modules/OnlineUpdateDialogs.rb
@@ -304,12 +304,6 @@ module Yast
 
       detailsButton = PushButton(Id(:details), detailsStringOff)
 
-      detailsTerm = HBox(
-        HSpacing(0.5),
-        HWeight(1, RichText(Opt(:plainText), details)),
-        HSpacing(0.5)
-      )
-
       buttons = nil
       if pre
         buttons = HBox(
@@ -553,7 +547,7 @@ module Yast
       )
 
       UI.OpenDialog(dialog_description)
-      user_ret = UI.UserInput
+      UI.UserInput
       UI.CloseDialog
     end
 


### PR DESCRIPTION
## Problem

Refresh of all repositories was unconditionally invoked with each run of online update. Even when the online update is run e.g. per minute basis.

- https://bugzilla.suse.com/show_bug.cgi?id=1204907


## Solution

It was caused by old workaround [here](https://github.com/yast/yast-online-update/commit/899a742d56f5d9580b9e129cc4463d127da5280e). The workaround was removed.
