### PR TITLE
Try requiring dbus early (bsc#1205913)

### DIFF
--- a/package/yast2-online-update.changes
+++ b/package/yast2-online-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  9 08:41:43 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Fix showing of release notes when we update a rubygem
+  (bsc#1205913)
+- 4.2.3
+
+-------------------------------------------------------------------
 Mon Aug 26 09:35:43 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-online-update.spec
+++ b/package/yast2-online-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Url:            https://github.com/yast/yast-online-update
 Summary:        YaST2 - Online Update (YOU)

--- a/src/clients/online_update.rb
+++ b/src/clients/online_update.rb
@@ -23,6 +23,18 @@
 # Authors:	Gabriele Strattner <gs@suse.de>
 #		Stefan Schubert <schubi@suse.de>
 #              Cornelius Schumacher <cschum@suse.de>
+
+# bsc#1205913
+# 1. We may update a rubygem
+# 2. inst_release_notes may be called, which (indirectly) requires dbus
+# Then rubygems would try loading the gemspec of the uninstalled older gem
+# and crash. Prevent it by requiring dbus early.
+begin
+      require "dbus"
+rescue LoadError
+      # Call site will check if it's there
+end
+
 module Yast
   class OnlineUpdateClient < Client
     def main


### PR DESCRIPTION
## Problem

When online_update deletes an old version of a gem, rubygems get confused and a "late" `require` will crash.

- https://bugzilla.suse.com/show_bug.cgi?id=1205913
- https://trello.com/c/A23PuTta/3270-sles4sap15-sp2-1205913-l3-yast-undefined-method-running-online-update


## Solution

Try requiring dbus early.

This is a second attempt, https://github.com/yast/yast-country/pull/305 alone did not work.

This one alone is enough: once the `require "dbus"` fails in clients/online_update.rb, the failing path in stub_specification.rb won't be hit again when we try requiring it in language_dbus.rb (yast-country)

## Are there similar instances of this bug waiting to strike?

Probably not: it needs a rubygem getting updated while YaST is running -> only online_update does it, and we fix its client here.

## Testing

- Automatic test: no. I can only imagine a complex integration test in openQA recreating the bug, IMHO not worth the effort.
- Tested manually and had the reporting customer test it successfully.


## Screenshots

N/A

