### PR TITLE
Fix showing of release notes when we update a rubygem (bsc#1205913) , SP3

### DIFF
--- a/package/yast2-online-update.changes
+++ b/package/yast2-online-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  9 08:41:43 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Fix showing of release notes when we update a rubygem
+  (bsc#1205913)
+- 4.2.3
+
+-------------------------------------------------------------------
 Mon Aug 26 09:35:43 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-online-update.spec
+++ b/package/yast2-online-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Url:            https://github.com/yast/yast-online-update
 Summary:        YaST2 - Online Update (YOU)

--- a/src/clients/online_update.rb
+++ b/src/clients/online_update.rb
@@ -23,6 +23,18 @@
 # Authors:	Gabriele Strattner <gs@suse.de>
 #		Stefan Schubert <schubi@suse.de>
 #              Cornelius Schumacher <cschum@suse.de>
+
+# bsc#1205913
+# 1. We may update a rubygem
+# 2. inst_release_notes may be called, which (indirectly) requires dbus
+# Then rubygems would try loading the gemspec of the uninstalled older gem
+# and crash. Prevent it by requiring dbus early.
+begin
+      require "dbus"
+rescue LoadError
+      # Call site will check if it's there
+end
+
 module Yast
   class OnlineUpdateClient < Client
     def main


### PR DESCRIPTION
Original fix: #40 for SLE-15-SP2

Merging it to SP3

Note that there have been no code changes SP2..SP3, so the version can stay the same.

Regarding CI... the SP3 branch deleted the Dockerfile and [there are no SP3 containers on registry.opensuse.org](https://registry.opensuse.org/cgi-bin/cooverview?srch_term=project%3D%5E%28%3F%21%28open%29%3FSUSE%3A%7Ckubic%3A%7Chome%3A%29)... which I don't understand. That's also the reason for the GH Action CI failures.