### PR TITLE
Fix showing of release notes when we update a rubygem (bsc#1205913) , SP5

### DIFF
--- a/package/yast2-online-update.changes
+++ b/package/yast2-online-update.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  9 08:41:43 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Fix showing of release notes when we update a rubygem
+  (bsc#1205913)
+- 4.5.3
+
+-------------------------------------------------------------------
 Mon Nov 21 11:45:35 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - bsc#1204907

--- a/package/yast2-online-update.spec
+++ b/package/yast2-online-update.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-online-update
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 Url:            https://github.com/yast/yast-online-update
 Summary:        YaST2 - Online Update (YOU)

--- a/src/clients/online_update.rb
+++ b/src/clients/online_update.rb
@@ -24,6 +24,17 @@
 #		Stefan Schubert <schubi@suse.de>
 #              Cornelius Schumacher <cschum@suse.de>
 
+# bsc#1205913
+# 1. We may update a rubygem
+# 2. inst_release_notes may be called, which (indirectly) requires dbus
+# Then rubygems would try loading the gemspec of the uninstalled older gem
+# and crash. Prevent it by requiring dbus early.
+begin
+      require "dbus"
+rescue LoadError
+      # Call site will check if it's there
+end
+
 require "y2packager/resolvable"
 require "ui/ui_extension_checker"
 


### PR DESCRIPTION
Original fix: https://github.com/yast/yast-online-update/pull/40 for SLE-15-SP2

Merging it to SP5
